### PR TITLE
Add binder

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Go to definition extension for JupyterLab
 
+[![Binder](https://beta.mybinder.org/badge.svg)](https://mybinder.org/v2/gh/krassowski/jupyterlab-go-to-definition/master?urlpath=lab/tree/examples/demo.ipynb)
+
 Jump to definition of a variable or function in JupyterLab notebook and file editor.
 
 Use <kbd>Alt</kbd> + <kbd>click</kbd> to jump to a definition using your mouse, or <kbd>Ctrl</kbd> + <kbd>Alt</kbd> + <kbd>B</kbd> keyboard-only alternative.

--- a/examples/demo.ipynb
+++ b/examples/demo.ipynb
@@ -1,0 +1,85 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# jupyterlab-go-to-definition demo\n",
+    "\n",
+    "First, we will define a function"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def add(a, b):\n",
+    "    return a +b"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Next, we will reference that function"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "3"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "add(1,2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Try <kbd>ALT+CLICK</kbd> on `add` and it will jump to the definition in the previous cell 👍👍"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/postBuild
+++ b/postBuild
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+jupyter labextension install @krassowski/jupyterlab_go_to_definition

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+jupyterlab>=0.35.0


### PR DESCRIPTION
This adds a binder button to the README and necessary postBuild file to install the jupyterlab-go-to-definition labextension.

To try out: https://mybinder.org/v2/gh/gnestor/jupyterlab-go-to-definition/binder?urlpath=lab/tree/examples/demo.ipynb